### PR TITLE
feat: Добавить Visitor для проверки типов

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -850,9 +850,10 @@ class TypeChecker : public Visitor {
     }
 
     void checkConditionalExpression(NExpression* expression) {
+        // check if type of expression->type pointer is pointer to class NBoolType
         if (expression->type == nullptr) {
             std::cout << "TypeError: expression type not known (cannot be approved)";
-        } else if (expression->type != new NBoolType()) {
+        } else if (dynamic_cast<NBoolType*>(expression->type) == nullptr) {
             std::cout << "TypeError: wrong type (condition is ";
             expression->type->visit(this->prettyPrinter);
             std::cout << " but should be bool)";
@@ -914,12 +915,10 @@ class TypeChecker : public Visitor {
         std::cout << ")" << std::endl;
     }
 
-    // TODO: check type for several function return types
-    // TODO: check type for function calls
-    // TODO: add
-    // TODO: add tables and structs
-    //      TODO: add type checking for tables and structs(declaration, access, etc.)
-    // TODO: check type for binary/unary operators
-    //      TODO: define accepted types for each operator
+    // TODO: check type for several function return types (not necessary for now, only one return type is allowed)
+    // TODO: check type for function calls (check if the function is defined, check if the number of arguments is correct, check if the types of the arguments are correct)
+    // TODO: add type checking for tables and structs(declaration, access, etc.)
+    // TODO: check type for binary/unary operators (Camil)
+    //      TODO: define accepted types for each operator (Camil)
     // TODO: check type for all conditional statements
 };

--- a/src/node.h
+++ b/src/node.h
@@ -27,7 +27,7 @@ class NIfStatement;
 class NNumericForStatement;
 class NGenericForStatement;
 class NDeclarationStatement;
-class NAssignmentStatement ;
+class NAssignmentStatement;
 class NReturnStatement;
 class NFunctionDeclaration;
 class NAccessKey;
@@ -80,7 +80,7 @@ class Visitor {
     virtual void visitNIfStatement(NIfStatement* node) = 0;
     virtual void visitNNumericForStatement(NNumericForStatement* node) = 0;
     virtual void visitNGenericForStatement(NGenericForStatement* node) = 0;
-    virtual void visitNAssignmentStatement(NAssignmentStatement * node) = 0;
+    virtual void visitNAssignmentStatement(NAssignmentStatement* node) = 0;
     virtual void visitNDeclarationStatement(NDeclarationStatement* node) = 0;
     virtual void visitNReturnStatement(NReturnStatement* node) = 0;
     virtual void visitNBlock(NBlock* node) = 0;
@@ -280,8 +280,8 @@ class NTableField : public Node {
 class NTableConstructor : public NExpression {
    public:
     // Two different ways to create a table
-    std::vector<keyvalPair*> keyvalPairList; // Either one of these
-    ExpressionList expressionList;           // or both are nullptr!!
+    std::vector<keyvalPair*> keyvalPairList;  // Either one of these
+    ExpressionList expressionList;            // or both are nullptr!!
     NTableConstructor() {}
 
     virtual void visit(Visitor* v) { v->visitNTableConstructor(this); }
@@ -390,7 +390,7 @@ class NAssignmentStatement : public NStatement {
         : ident(ident), type(nullptr), expression(expression) {}
 
     NAssignmentStatement(NExpression* ident, NType* type,
-                          NExpression* expression)
+                         NExpression* expression)
         : ident(ident), type(type), expression(expression) {}
 
     virtual void visit(Visitor* v) { v->visitNAssignmentStatement(this); }

--- a/src/node.h
+++ b/src/node.h
@@ -635,7 +635,7 @@ class PrettyPrintVisitor : public Visitor {
         std::cout << ")";
     }
 
-    virtual void visitNRepeatStatement(NRepeatUntilStatement* node) {
+    virtual void visitNRepeatUntilStatement(NRepeatUntilStatement* node) {
         std::cout << "NRepeatUntilStatement(condition=";
         node->condition->visit(this);
         std::cout << ", block=\n\t";


### PR DESCRIPTION
### TODO in node.h mainly:
-  check type for several function return types (e.g. function() -> int, string). _**How to store such type???**_
> Right now type is stored as a field of class NExpression
class NExpression : public NStatement {
   public:
    NType* type = nullptr;
    virtual void visit(Visitor* v) { v->visitNExpression(this); }
};
-   check type for expression calls (look for function definition, arguments, return type)

>  As it is an expression call, check that expression is function identifier or its return type is function with according type.

-   define accepted types for each operator

> What operator can be uses with what types, or suggest and implement yourself a logic of operator overloading)

- check type for binary/unary operators
-   check type for all conditional statements and for statements

> Easy, just need to write it, there are examples in code.

### Need to be added to Bison:
-   add tables and structs

> Some classes exist in node.h, need to add it to Bison and implement access to such.

-   add type checking for tables and structs(declaration, access, etc.)